### PR TITLE
feat: CustomException, Security Cors 설정

### DIFF
--- a/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
+++ b/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
@@ -2,18 +2,23 @@ package com.midasdev.mochat.config.security;
 
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Slf4j
 @Configuration
@@ -22,21 +27,25 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class SecurityConfig {
 
     public final AuthenticationSuccessHandler authenticationSuccessHandler;
+    public final AuthenticationEntryPoint authenticationEntryPoint;
+
+    @Value("${client.url}")
+    private String clientUrl;
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web ->
-                web.ignoring()
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/api/v1/sample")
-                        );
-    }
-
-    @Bean
-    public SecurityFilterChain oidcLoginFilterChain(HttpSecurity httpSecurity) throws Exception{
+    public SecurityFilterChain oidcLoginFilterChain(HttpSecurity httpSecurity) throws Exception {
         log.info("SecurityFilterChain -> OidcLoginFilterChain");
         return httpSecurity
-                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+                .exceptionHandling(config ->
+                                           config.authenticationEntryPoint(authenticationEntryPoint))
+                .securityMatcher("/api/**")
+                .authorizeHttpRequests(
+                        request ->
+                                request.requestMatchers("/api/v1/sample/**")
+                                       .permitAll()
+                                       .anyRequest().authenticated())
+                .csrf(CsrfConfigurer::disable)
+                .cors(config -> config.configurationSource(corsConfigurationSource()))
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorizationEndpoint -> authorizationEndpoint
                                 .baseUri("/security/oauth2/authorization"))
@@ -52,8 +61,22 @@ public class SecurityConfig {
     }
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        // 만약 cors 설정 종류가 많아지면 함수화
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(clientUrl));
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
     ObservationRegistryCustomizer<ObservationRegistry> addTextHandler() {
         return registry -> registry.observationConfig().observationHandler(new ObservationTextPublisher());
     }
+
 
 }

--- a/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
+++ b/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
@@ -32,6 +32,9 @@ public class SecurityConfig {
     @Value("${client.url}")
     private String clientUrl;
 
+    @Value("${security.permitted-urls}")
+    private String[] permitUrlPatterns;
+
     @Bean
     public SecurityFilterChain oidcLoginFilterChain(HttpSecurity httpSecurity) throws Exception {
         log.info("SecurityFilterChain -> OidcLoginFilterChain");
@@ -41,7 +44,7 @@ public class SecurityConfig {
                 .securityMatcher("/api/**")
                 .authorizeHttpRequests(
                         request ->
-                                request.requestMatchers("/api/v1/sample/**")
+                                request.requestMatchers(permitUrlPatterns)
                                        .permitAll()
                                        .anyRequest().authenticated())
                 .csrf(CsrfConfigurer::disable)

--- a/src/main/java/com/midasdev/mochat/config/security/handler/DefaultAuthenticationEntryPoint.java
+++ b/src/main/java/com/midasdev/mochat/config/security/handler/DefaultAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.midasdev.mochat.config.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DefaultAuthenticationEntryPoint extends Http403ForbiddenEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException arg2) throws IOException {
+        log.info("Authentication Fail...");
+        super.commence(request, response, arg2);
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/global/advice/GlobalControllerAdvice.java
+++ b/src/main/java/com/midasdev/mochat/global/advice/GlobalControllerAdvice.java
@@ -1,0 +1,26 @@
+package com.midasdev.mochat.global.advice;
+
+import com.midasdev.mochat.global.exception.ApplicationException;
+import com.midasdev.mochat.global.response.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    /*
+    에러 포맷
+    1. httpStatus
+    2. errorCode
+    3. errorMessage
+     */
+
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ExceptionResponse> handleApplicationException(ApplicationException exception) {
+        return ResponseEntity.status(exception.getExceptionType().getHttpStatus()).body(ExceptionResponse.from(exception));
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/global/exception/ApplicationException.java
+++ b/src/main/java/com/midasdev/mochat/global/exception/ApplicationException.java
@@ -1,0 +1,21 @@
+package com.midasdev.mochat.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApplicationException extends RuntimeException {
+
+    private final ApplicationExceptionType exceptionType;
+    private final Object[] messageArguments;
+
+    public ApplicationException(ApplicationExceptionType exceptionType, Object... args) {
+        super(exceptionType.getErrorMessage(args));
+        this.exceptionType = exceptionType;
+        this.messageArguments = args;
+    }
+
+    public String getMessage() {
+        return exceptionType.getErrorMessage(messageArguments);
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
@@ -1,0 +1,21 @@
+package com.midasdev.mochat.global.exception;
+
+import java.text.MessageFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ApplicationExceptionType {
+
+    UNDEFINED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "ERR_GLOBAL_999", "정의되지 않은 에러입니다. : {0}");
+
+    private final HttpStatus httpStatus;
+    private final String exceptionCode;
+    private final String errorMessage;
+
+    public String getErrorMessage(Object... args) {
+        return MessageFormat.format(errorMessage, args);
+    }
+}

--- a/src/main/java/com/midasdev/mochat/global/response/ExceptionResponse.java
+++ b/src/main/java/com/midasdev/mochat/global/response/ExceptionResponse.java
@@ -1,0 +1,19 @@
+package com.midasdev.mochat.global.response;
+
+import com.midasdev.mochat.global.exception.ApplicationException;
+import com.midasdev.mochat.global.exception.ApplicationExceptionType;
+import lombok.Builder;
+
+@Builder
+public record ExceptionResponse(String httpStatus, String errorCode, String message) {
+
+    public static ExceptionResponse from(ApplicationException exception) {
+        ApplicationExceptionType exceptionType = exception.getExceptionType();
+        return ExceptionResponse.builder()
+                                .httpStatus(exceptionType.getHttpStatus().toString())
+                                .errorCode(exceptionType.getExceptionCode())
+                                .message(exception.getMessage())
+                                .build();
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/sample/controller/SampleController.java
+++ b/src/main/java/com/midasdev/mochat/sample/controller/SampleController.java
@@ -1,7 +1,10 @@
 package com.midasdev.mochat.sample.controller;
 
+import com.midasdev.mochat.global.exception.ApplicationException;
+import com.midasdev.mochat.global.exception.ApplicationExceptionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,8 +19,13 @@ public class SampleController {
 
     @PostMapping
     public String createSampleData() {
-        log.info("createSampleData");
         sampleSpringDataRepository.save(SampleEntity.getSample());
         return "Success!";
+    }
+
+    @GetMapping("/error")
+    public String errorTest() {
+        log.info("createSampleData");
+        throw new ApplicationException(ApplicationExceptionType.UNDEFINED_EXCEPTION, "test");
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -53,3 +53,7 @@ client:
   url: ${CLIENT_URL}
   redirect:
     auth-success: ${CLIENT_REDIRECT_AUTH_SUCCESS_PATH}
+
+# 인증을 거치지 않는 API 설정
+security:
+  permitted-urls: ${SECURITY_PERMITTED_URLS}


### PR DESCRIPTION
# Desc
- application의 Exception 틀 생성
- Security Cors 설정 및 permitted url 환경변수로 관리
- Sample API error test api 추가

## ApplicationException
- front 확인 방법 : `error.response.data`
- errorCode : Application에서 정의한 에러에 대한 고유 코드입니다. 해당 에러를 발생시킬 수 있는 자세한 사항에 대해 노션에 문서화를 합니다.
- 형식
```json
{
    "errorCode": "ERR_GLOBAL_999",
    "httpStatus": "500 INTERNAL_SERVER_ERROR",
    "message": "정의되지 않은 에러입니다."
}
```
