### PR TITLE
[feat] 서버 인증 토큰 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // validations
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/midasdev/mochat/auth/AuthController.java
+++ b/src/main/java/com/midasdev/mochat/auth/AuthController.java
@@ -2,9 +2,14 @@ package com.midasdev.mochat.auth;
 
 import com.midasdev.mochat.auth.dto.TokenRequestUser;
 import com.midasdev.mochat.auth.dto.request.AuthRequest;
+import com.midasdev.mochat.auth.dto.request.TokenReIssueRequest;
 import com.midasdev.mochat.auth.dto.response.AuthResponse;
+import com.midasdev.mochat.auth.dto.response.TokenReIssueResponse;
 import com.midasdev.mochat.auth.service.AuthService;
 import com.midasdev.mochat.config.security.jwt.AuthorizationToken;
+import com.midasdev.mochat.config.security.jwt.JwtClaimResolver;
+import com.midasdev.mochat.config.security.jwt.TokenAttribute;
+import com.midasdev.mochat.config.security.jwt.constant.JwtComponent;
 import com.midasdev.mochat.member.domain.Member;
 import com.midasdev.mochat.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -25,6 +30,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final MemberService memberService;
+    private final JwtClaimResolver jwtClaimResolver;
 
     @PostMapping
     public ResponseEntity<AuthResponse> generateToken(@RequestBody @Valid AuthRequest authRequest) {
@@ -43,6 +49,24 @@ public class AuthController {
 
         return ResponseEntity.ok(AuthResponse.from(member, generatedToken, memberOptional.isEmpty()));
 
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenReIssueResponse> reIssueToken(@RequestBody TokenReIssueRequest tokenReIssueRequest) {
+        Long memberId = Long.valueOf(
+                jwtClaimResolver.extractValueWithoutValidation(tokenReIssueRequest.refreshToken(), TokenAttribute.SUB.getAttribute(),
+                                                               JwtComponent.BODY));
+
+        // 1. Body의 refreshToken이 member의 refreshToken과 일치하는지 확인
+        memberService.verifyRefreshToken(memberId, tokenReIssueRequest.refreshToken());
+        // 2. 일치한다면 새로운 accessToken, refreshToken 발급
+        AuthorizationToken generatedToken = authService.issueAuthorizationToken(memberId);
+        TokenReIssueResponse tokenReIssueResponse = TokenReIssueResponse.builder()
+                                                                        .memberId(memberId)
+                                                                        .accessToken(generatedToken.getAccessToken())
+                                                                        .refreshToken(generatedToken.getRefreshToken())
+                                                                        .build();
+        return ResponseEntity.ok(tokenReIssueResponse);
     }
 
 }

--- a/src/main/java/com/midasdev/mochat/auth/dto/request/TokenReIssueRequest.java
+++ b/src/main/java/com/midasdev/mochat/auth/dto/request/TokenReIssueRequest.java
@@ -1,0 +1,5 @@
+package com.midasdev.mochat.auth.dto.request;
+
+public record TokenReIssueRequest(String refreshToken) {
+
+}

--- a/src/main/java/com/midasdev/mochat/auth/dto/response/TokenReIssueResponse.java
+++ b/src/main/java/com/midasdev/mochat/auth/dto/response/TokenReIssueResponse.java
@@ -1,0 +1,8 @@
+package com.midasdev.mochat.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TokenReIssueResponse(Long memberId, String accessToken, String refreshToken) {
+
+}

--- a/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
+++ b/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
@@ -44,4 +44,10 @@ public class AuthService {
         return authorizationToken;
     }
 
+    public AuthorizationToken issueAuthorizationToken(Long memberId) {
+        AuthorizationToken authorizationToken = jwtProvider.createAuthorizationToken(memberId);
+        refreshTokenRedisRepository.save(RefreshToken.from(memberId, authorizationToken));
+        return authorizationToken;
+    }
+
 }

--- a/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
+++ b/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
@@ -8,8 +8,10 @@ import com.midasdev.mochat.config.security.id_token.IdToken;
 import com.midasdev.mochat.config.security.id_token.IdTokenValidator;
 import com.midasdev.mochat.config.security.id_token.IdTokenValidatorFactory;
 import com.midasdev.mochat.config.security.jwt.AuthorizationToken;
+import com.midasdev.mochat.config.security.jwt.JwtClaimResolver;
 import com.midasdev.mochat.config.security.jwt.JwtProvider;
-import com.midasdev.mochat.config.security.jwt.JwtValidator;
+import com.midasdev.mochat.config.security.jwt.TokenAttribute;
+import com.midasdev.mochat.config.security.jwt.TokenType;
 import com.midasdev.mochat.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,14 +22,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final JwtValidator jwtValidator;
+    private final JwtClaimResolver jwtClaimResolver;
     private final JwtProvider jwtProvider;
     private final IdTokenValidatorFactory idTokenValidatorFactory;
 
     public TokenRequestUser extractUserInfo(AuthRequest authRequest) {
 
         OauthProvider oauthProvider = authRequest.oauthProvider();
-        String idTokenFromRequest = jwtValidator.extractIdTokenFromAuthToken(authRequest.authToken());
+        String idTokenFromRequest = jwtClaimResolver.extractValue(authRequest.authToken(), TokenType.AUTH, TokenAttribute.ID_TOKEN.getAttribute());
         IdTokenValidator validator = idTokenValidatorFactory.getValidator(oauthProvider);
         IdToken idToken = validator.validate(idTokenFromRequest, oauthProvider);
         return new TokenRequestUser(new OauthAccount(oauthProvider, idToken.sub()), idToken.nickname());

--- a/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
+++ b/src/main/java/com/midasdev/mochat/auth/service/AuthService.java
@@ -10,8 +10,10 @@ import com.midasdev.mochat.config.security.id_token.IdTokenValidatorFactory;
 import com.midasdev.mochat.config.security.jwt.AuthorizationToken;
 import com.midasdev.mochat.config.security.jwt.JwtClaimResolver;
 import com.midasdev.mochat.config.security.jwt.JwtProvider;
+import com.midasdev.mochat.config.security.jwt.RefreshToken;
 import com.midasdev.mochat.config.security.jwt.TokenAttribute;
 import com.midasdev.mochat.config.security.jwt.TokenType;
+import com.midasdev.mochat.config.security.jwt.repository.RefreshTokenRedisRepository;
 import com.midasdev.mochat.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,7 @@ public class AuthService {
     private final JwtClaimResolver jwtClaimResolver;
     private final JwtProvider jwtProvider;
     private final IdTokenValidatorFactory idTokenValidatorFactory;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     public TokenRequestUser extractUserInfo(AuthRequest authRequest) {
 
@@ -36,7 +39,9 @@ public class AuthService {
     }
 
     public AuthorizationToken issueAuthorizationToken(Member member) {
-        return jwtProvider.createAuthorizationToken(member.getId());
+        AuthorizationToken authorizationToken = jwtProvider.createAuthorizationToken(member.getId());
+        refreshTokenRedisRepository.save(RefreshToken.from(member.getId(), authorizationToken));
+        return authorizationToken;
     }
 
 }

--- a/src/main/java/com/midasdev/mochat/config/redis/RedisConfig.java
+++ b/src/main/java/com/midasdev/mochat/config/redis/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.midasdev.mochat.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.username}")
+    private String username;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(host);
+        redisConfig.setPort(port);
+        redisConfig.setUsername(username);
+        redisConfig.setPassword(password);
+        return new LettuceConnectionFactory(redisConfig);
+    }
+}

--- a/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
+++ b/src/main/java/com/midasdev/mochat/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.midasdev.mochat.config.security;
 
 import com.midasdev.mochat.config.security.filter.ExceptionHandlerFilter;
+import com.midasdev.mochat.config.security.filter.JwtAuthenticationFilter;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationF
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -31,6 +33,7 @@ public class SecurityConfig {
     public final AuthenticationSuccessHandler authenticationSuccessHandler;
     public final AuthenticationEntryPoint authenticationEntryPoint;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Value("${client.url}")
     private String clientUrl;
@@ -59,6 +62,7 @@ public class SecurityConfig {
                         .successHandler(authenticationSuccessHandler)
                 )
                 .addFilterBefore(exceptionHandlerFilter, OAuth2LoginAuthenticationFilter.class)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class) // TODO 필터체인 분리
                 .build();
     }
 

--- a/src/main/java/com/midasdev/mochat/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/midasdev/mochat/config/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.midasdev.mochat.config.security.filter;
+
+import com.midasdev.mochat.config.security.jwt.GrantType;
+import com.midasdev.mochat.config.security.jwt.JwtClaimResolver;
+import com.midasdev.mochat.config.security.jwt.TokenAttribute;
+import com.midasdev.mochat.config.security.jwt.TokenType;
+import com.midasdev.mochat.global.exception.ApplicationException;
+import com.midasdev.mochat.global.exception.ApplicationExceptionType;
+import com.midasdev.mochat.global.util.assertion.Assertion;
+import com.midasdev.mochat.member.domain.Member;
+import com.midasdev.mochat.member.service.MemberService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final JwtClaimResolver jwtClaimResolver;
+    private final MemberService memberService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        getTokenFromHeader(request).ifPresent((token) -> {
+            // 1. Bearer 토큰 검증
+            String accessToken = validateBearerToken(token);
+
+            // 2. AccessToken 에서 memberId 가져오기
+            Long memberId = Long.valueOf(
+                    jwtClaimResolver.extractValue(accessToken, TokenType.ACCESS, TokenAttribute.SUB.getAttribute())
+            );
+
+            // 3. memberId에 대한 인증 정보 저장
+            setAuthenticationInSecurityContext(memberId);
+        });
+
+        doFilter(request, response, filterChain);
+    }
+
+    private void setAuthenticationInSecurityContext(Long memberId) {
+        // 1. memberId 있는지 검사
+        Member member = memberService.findMemberById(memberId)
+                                     .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.MEMBER_NOT_FOUND_BY_ID, memberId));
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(member, null, new ArrayList<>());
+
+        // 2. memberId에 대한 인증 정보 저장
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    private String validateBearerToken(String token) {
+        Assertion.with(token)
+                 .setValidation((t) -> t.startsWith(GrantType.BEARER.getType()))
+                 .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.NOT_BEARER_TOKEN));
+        return token.substring(GrantType.BEARER.getType().length()).strip();
+    }
+
+    public Optional<String> getTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(AUTHORIZATION_HEADER));
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/config/security/id_token/IdTokenValidator.java
+++ b/src/main/java/com/midasdev/mochat/config/security/id_token/IdTokenValidator.java
@@ -4,6 +4,7 @@ import com.midasdev.mochat.config.security.Oauth.OauthProvider;
 import com.midasdev.mochat.config.security.jwt.JwtClaimResolver;
 import com.midasdev.mochat.config.security.jwt.JwtValidator;
 import com.midasdev.mochat.config.security.jwt.TokenAttribute;
+import com.midasdev.mochat.config.security.jwt.constant.JwtComponent;
 import com.midasdev.mochat.global.exception.ApplicationException;
 import com.midasdev.mochat.global.exception.ApplicationExceptionType;
 import com.nimbusds.jose.JOSEException;
@@ -28,7 +29,7 @@ public abstract class IdTokenValidator {
 
         // 2. IdToken의 kid로 적절한 public key를 가져온다 -> kakao 검증 글 참고
         // 2-1. Kid 가져오기
-        String kid = jwtClaimResolver.extractValueWithoutValidation(idTokenFromRequest, "kid");
+        String kid = jwtClaimResolver.extractValueWithoutValidation(idTokenFromRequest, TokenAttribute.KID.getAttribute(), JwtComponent.HEADER);
 
         // 2-2. kid에 맞는 public key 가져오기
         Key publicKey;

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/GrantType.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/GrantType.java
@@ -1,5 +1,8 @@
 package com.midasdev.mochat.config.security.jwt;
 
+import lombok.Getter;
+
+@Getter
 public enum GrantType {
     BEARER("Bearer");
 

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
@@ -20,31 +20,6 @@ public class JwtClaimResolver {
 
     private final JwtValidator jwtValidator;
 
-    public String extractValueWithoutValidation(String token, String key) {
-        // REFACTOR: extractValueWithoutValidation 로 바꾸기
-        return extractFromHeader(token, key);
-    }
-
-    private String extractFromHeader(String token, String key) {
-        // REFACTOR: extractValueWithoutValidation 로 바꾸기
-        String headerToken = token.split("\\.")[0];
-        byte[] decodedHeader = Base64.getDecoder().decode(headerToken);
-        Map<String, Object> headerData;
-        try {
-            headerData = new ObjectMapper().readValue(decodedHeader, new TypeReference<>() {
-            });
-        } catch (IOException e) {
-            throw new ApplicationException(ApplicationExceptionType.JWT_PARSING_EXCEPTION, "HEADER", key);
-        }
-
-        return headerData.get(key).toString();
-    }
-
-    public String extractValue(String token, TokenType tokenType, String key) {
-        Jws<Claims> claimsJws = jwtValidator.validate(token, tokenType);
-        return getFromClaim(claimsJws, key);
-    }
-
     public String extractValueWithoutValidation(String token, String key, JwtComponent jwtComponent) {
         String tokenComponent = token.split("\\.")[jwtComponent.getIndex()];
         byte[] decodedComponent = Base64.getDecoder().decode(tokenComponent);
@@ -59,6 +34,11 @@ public class JwtClaimResolver {
                  .setValidation(jwtComponentData::containsKey)
                  .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.JWT_CLAIMS_KEY_NOT_FOUND, key));
         return jwtComponentData.get(key).toString();
+    }
+
+    public String extractValue(String token, TokenType tokenType, String key) {
+        Jws<Claims> claimsJws = jwtValidator.validate(token, tokenType);
+        return getFromClaim(claimsJws, key);
     }
 
     public String getFromClaim(Jws<Claims> claimsJws, String key) {

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
@@ -2,8 +2,10 @@ package com.midasdev.mochat.config.security.jwt;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.midasdev.mochat.config.security.jwt.constant.JwtComponent;
 import com.midasdev.mochat.global.exception.ApplicationException;
 import com.midasdev.mochat.global.exception.ApplicationExceptionType;
+import com.midasdev.mochat.global.util.assertion.Assertion;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import java.io.IOException;
@@ -19,10 +21,12 @@ public class JwtClaimResolver {
     private final JwtValidator jwtValidator;
 
     public String extractValueWithoutValidation(String token, String key) {
+        // REFACTOR: extractValueWithoutValidation 로 바꾸기
         return extractFromHeader(token, key);
     }
 
     private String extractFromHeader(String token, String key) {
+        // REFACTOR: extractValueWithoutValidation 로 바꾸기
         String headerToken = token.split("\\.")[0];
         byte[] decodedHeader = Base64.getDecoder().decode(headerToken);
         Map<String, Object> headerData;
@@ -39,6 +43,22 @@ public class JwtClaimResolver {
     public String extractValue(String token, TokenType tokenType, String key) {
         Jws<Claims> claimsJws = jwtValidator.validate(token, tokenType);
         return getFromClaim(claimsJws, key);
+    }
+
+    public String extractValueWithoutValidation(String token, String key, JwtComponent jwtComponent) {
+        String tokenComponent = token.split("\\.")[jwtComponent.getIndex()];
+        byte[] decodedComponent = Base64.getDecoder().decode(tokenComponent);
+        Map<String, Object> jwtComponentData;
+        try {
+            jwtComponentData = new ObjectMapper().readValue(decodedComponent, new TypeReference<>() {
+            });
+        } catch (IOException e) {
+            throw new ApplicationException(ApplicationExceptionType.JWT_PARSING_EXCEPTION, jwtComponent.getName());
+        }
+        Assertion.with(key)
+                 .setValidation(jwtComponentData::containsKey)
+                 .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.JWT_CLAIMS_KEY_NOT_FOUND, key));
+        return jwtComponentData.get(key).toString();
     }
 
     public String getFromClaim(Jws<Claims> claimsJws, String key) {

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/JwtClaimResolver.java
@@ -9,10 +9,14 @@ import io.jsonwebtoken.Jws;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class JwtClaimResolver {
+
+    private final JwtValidator jwtValidator;
 
     public String extractValueWithoutValidation(String token, String key) {
         return extractFromHeader(token, key);
@@ -23,7 +27,8 @@ public class JwtClaimResolver {
         byte[] decodedHeader = Base64.getDecoder().decode(headerToken);
         Map<String, Object> headerData;
         try {
-            headerData = new ObjectMapper().readValue(decodedHeader, new TypeReference<>() {});
+            headerData = new ObjectMapper().readValue(decodedHeader, new TypeReference<>() {
+            });
         } catch (IOException e) {
             throw new ApplicationException(ApplicationExceptionType.JWT_PARSING_EXCEPTION, "HEADER", key);
         }
@@ -31,7 +36,13 @@ public class JwtClaimResolver {
         return headerData.get(key).toString();
     }
 
+    public String extractValue(String token, TokenType tokenType, String key) {
+        Jws<Claims> claimsJws = jwtValidator.validate(token, tokenType);
+        return getFromClaim(claimsJws, key);
+    }
+
     public String getFromClaim(Jws<Claims> claimsJws, String key) {
         return (String) claimsJws.getBody().get(key);
     }
+
 }

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/JwtProvider.java
@@ -42,7 +42,7 @@ public class JwtProvider {
         Instant expiredTime = Instant.now().plus(validationSecond, ChronoUnit.SECONDS);
         return Jwts.builder()
                    .setSubject(subject)
-                   .setClaims(claims)
+                   .addClaims(claims)
                    .signWith(jwtProperty.getKey(), SignatureAlgorithm.HS512)
                    .setExpiration(Date.from(expiredTime))
                    .compact();

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/JwtValidator.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/JwtValidator.java
@@ -22,13 +22,13 @@ public class JwtValidator {
 
     private final JwtProperty jwtProperty;
 
-    public String validate(String token, TokenType tokenType) {
+    public Jws<Claims> validate(String token, TokenType tokenType) {
         Jws<Claims> claim = validateJWT(token);
         String type = (String) claim.getBody().get(TokenAttribute.TYPE.getAttribute());
         Assertion.with(type)
                  .setValidation(tokenType::match)
                  .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.TOKEN_TYPE_MISMATCH, type, tokenType));
-        return (String) claim.getBody().get(TokenAttribute.ID_TOKEN.getAttribute());
+        return claim;
     }
 
     public Jws<Claims> validateJWT(String token) {
@@ -69,10 +69,6 @@ public class JwtValidator {
             log.error("JWT parsing 중 처리되지 않은 Exception 발생", e);
             throw new ApplicationException(ApplicationExceptionType.UNDEFINED_EXCEPTION, "unknown jwt parsing exception");
         }
-    }
-
-    public String extractIdTokenFromAuthToken(String authToken) {
-        return validate(authToken, TokenType.AUTH);
     }
 
 }

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/RefreshToken.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/RefreshToken.java
@@ -1,0 +1,25 @@
+package com.midasdev.mochat.config.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "refresh", timeToLive = 1209600)
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+    private String token;
+
+    public static RefreshToken from(Long memberId, AuthorizationToken authorizationToken) {
+        return new RefreshToken(memberId, authorizationToken.getRefreshToken());
+    }
+
+    public boolean isSameToken(String refreshToken) {
+        return this.token.equals(refreshToken);
+    }
+
+}

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/TokenAttribute.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/TokenAttribute.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum TokenAttribute {
-    TYPE("type"), ID_TOKEN("idToken"), SUB("sub"), NICKNAME("nickname");
+    TYPE("type"), ID_TOKEN("idToken"), SUB("sub"), NICKNAME("nickname"), KID("kid");
 
     private final String attribute;
 

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/constant/JwtComponent.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/constant/JwtComponent.java
@@ -1,0 +1,16 @@
+package com.midasdev.mochat.config.security.jwt.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtComponent {
+    HEADER(0, "HEADER"), BODY(1, "BODY");
+
+    int index;
+    String name;
+
+    JwtComponent(int index, String name) {
+        this.index = index;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/midasdev/mochat/config/security/jwt/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/midasdev/mochat/config/security/jwt/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,8 @@
+package com.midasdev.mochat.config.security.jwt.repository;
+
+import com.midasdev.mochat.config.security.jwt.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
@@ -8,9 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ApplicationExceptionType {
+    // member
+    MEMBER_NOT_FOUND_BY_ID(HttpStatus.BAD_REQUEST, "ERR_MEMBER_001", "해당 ID의 회원을 찾을 수 없습니다. : {0}"),
 
     // authentication
     TOKEN_AUTHENTICATION_EXCEPTION(HttpStatus.FORBIDDEN, "ERR_AUTH_001", "토큰 인증에 실패했습니다. : {0}"),
+    NOT_BEARER_TOKEN(HttpStatus.FORBIDDEN, "ERR_AUTH_002", "Bearer Token이 아닙니다."),
 
     // jwt
     JWT_EXPIRED(HttpStatus.BAD_REQUEST, "ERR_JWT_001", "JWT 기한이 만료되었습니다."),

--- a/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mochat/global/exception/ApplicationExceptionType.java
@@ -20,7 +20,14 @@ public enum ApplicationExceptionType {
     JWT_MALFORMED(HttpStatus.BAD_REQUEST, "ERR_JWT_002", "JWT가 손상되었습니다."),
     JWT_UNSUPPORTED(HttpStatus.BAD_REQUEST, "ERR_JWT_003", "지원되지 않는 JWT 입니다."),
     JWT_INVALID_SIGNATURE(HttpStatus.BAD_REQUEST, "ERR_JWT_004", "signature가 유효하지 않습니다."),
-    JWT_PARSING_EXCEPTION(HttpStatus.BAD_REQUEST, "ERR_JWT_005", "JWT {0}에 {1}에 대한 값이 없거나 유효하지 않습니다."),
+    /**
+     * - {0} : JWT Component name
+     */
+    JWT_PARSING_EXCEPTION(HttpStatus.BAD_REQUEST, "ERR_JWT_005", "JWT {0} 파싱 중 오류가 발생했습니다."),
+    /**
+     * - {0} : JWT Claims Key
+     */
+    JWT_CLAIMS_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "ERR_JWT_006", "JWT Claims Key를 찾을 수 없습니다. : {0}"),
 
     // token
     /**
@@ -29,6 +36,14 @@ public enum ApplicationExceptionType {
      * - {1} : 필요한 토큰 타입
      */
     TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "ERR_TOKEN_001", "토큰 타입이 맞지 않습니다. (전달된 토큰 : {0}, 필요한 토큰 {1})"),
+    /**
+     * - {0} : memberId
+     */
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "ERR_TOKEN_002", "MemberId {0}의 Refresh Token을 찾을 수 없습니다."),
+    /**
+     * - {0} : memberId
+     */
+    REFRESH_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "ERR_TOKEN_003", "MemberId {0}의 Refresh Token이 일치하지 않습니다."),
 
     // oidc public key
     OIDC_PUBLIC_KEY_PARSING_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "ERR_OIDC_001", "Provider {0}의 인증 public keys 에서 에러가 발생했습니다."),

--- a/src/main/java/com/midasdev/mochat/member/service/MemberService.java
+++ b/src/main/java/com/midasdev/mochat/member/service/MemberService.java
@@ -20,6 +20,10 @@ public class MemberService {
         return memberSpringDataRepository.findMemberByOauthAccountAndDeletedIsFalse(tokenRequestUser.oauthAccount());
     }
 
+    public Optional<Member> findMemberById(Long memberId) {
+        return memberSpringDataRepository.findById(memberId);
+    }
+
     @Transactional
     public Member register(TokenRequestUser tokenRequestUser) {
         Member member = Member.builder()

--- a/src/main/java/com/midasdev/mochat/member/service/MemberService.java
+++ b/src/main/java/com/midasdev/mochat/member/service/MemberService.java
@@ -1,6 +1,11 @@
 package com.midasdev.mochat.member.service;
 
 import com.midasdev.mochat.auth.dto.TokenRequestUser;
+import com.midasdev.mochat.config.security.jwt.RefreshToken;
+import com.midasdev.mochat.config.security.jwt.repository.RefreshTokenRedisRepository;
+import com.midasdev.mochat.global.exception.ApplicationException;
+import com.midasdev.mochat.global.exception.ApplicationExceptionType;
+import com.midasdev.mochat.global.util.assertion.Assertion;
 import com.midasdev.mochat.member.domain.Member;
 import com.midasdev.mochat.member.repository.MemberSpringDataRepository;
 import java.util.Optional;
@@ -14,6 +19,7 @@ public class MemberService {
 
     private final DefaultProfileImageService defaultProfileImageService;
     private final MemberSpringDataRepository memberSpringDataRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @Transactional(readOnly = true)
     public Optional<Member> findMemberByOauthAccount(TokenRequestUser tokenRequestUser) {
@@ -33,6 +39,17 @@ public class MemberService {
                               .build();
 
         return memberSpringDataRepository.save(member);
+    }
+
+    public void verifyRefreshToken(Long memberId, String refreshToken) {
+        // TEST: 저장된 refreshToken 여부에 대한 테스트
+        // TEST: refreshToken 일치 여부에 대한 테스트
+        RefreshToken refreshTokenFromRedis = refreshTokenRedisRepository.findById(memberId)
+                                                                        .orElseThrow(() -> new ApplicationException(
+                                                                                ApplicationExceptionType.REFRESH_TOKEN_NOT_FOUND, memberId));
+        Assertion.with(refreshToken)
+                 .setValidation(refreshTokenFromRedis::isSameToken)
+                 .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.REFRESH_TOKEN_MISMATCH, memberId));
     }
 
 }

--- a/src/main/java/com/midasdev/mochat/sample/controller/SampleAuthController.java
+++ b/src/main/java/com/midasdev/mochat/sample/controller/SampleAuthController.java
@@ -1,0 +1,28 @@
+package com.midasdev.mochat.sample.controller;
+
+import com.midasdev.mochat.member.domain.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/sample-auth")
+@RequiredArgsConstructor
+public class SampleAuthController {
+
+    private final SampleSpringDataRepository sampleSpringDataRepository;
+
+    @GetMapping
+    public ResponseEntity<List<SampleEntity>> findSample(@AuthenticationPrincipal Member member) {
+        log.info("member: {}", member.getId());
+        List<SampleEntity> all = sampleSpringDataRepository.findAll();
+        return new ResponseEntity<>(all, HttpStatus.OK);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,13 @@ spring:
       hibernate:
         format_sql: true
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
+
   security:
     oauth2:
       client:


### PR DESCRIPTION
# Desc

## Main Change
- accessToken을 통한 인증정보 저장
    - `@AuthenticationPrincipal` 을 통해 요청 멤버 접근 가능
 - redis 설정
 - refreshToken redis에 저장
 - accessToken 재발급 api 추가